### PR TITLE
Fixed authentication error.

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -118,7 +118,7 @@ class SteamHttpClient:
             steam_id = text[start:end]
 
             # find miniprofile id
-            profile_link = f'steamcommunity.com/profiles/{steam_id}/" data-miniprofile="'
+            profile_link = f'{url}" data-miniprofile="'
             start = text.find(profile_link)
             if start == -1:
                 logging.error("Can not parse backend response - no steam profile href")


### PR DESCRIPTION
Very recently, I started getting this error in the log file when using the plugin:
```
2019-11-15 15:45:44,436 - root - ERROR - Can not parse backend response - no steam profile href
2019-11-15 15:45:44,437 - root - DEBUG - Sending data: {"jsonrpc": "2.0", "id": "9", "error": {"code": 4, "message": "Backend responded in uknown way"}}
```
Looking through the plugin source code, it appears as if Valve has altered how the miniprofile value is stored in the user's profile page. This value is now stored along with the current URL.