### PR TITLE
Issue-74: increased connection timeout 30->120 for failing Steam connection

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -258,7 +258,7 @@ class SteamPlugin(Plugin):
             self._games_cache.loads(self.persistent_cache['games'])
 
         steam_run_task = self.create_task(self._steam_client.run(), "Run WebSocketClient")
-        connection_timeout = 30
+        connection_timeout = 120
         try:
             await asyncio.wait_for(self._user_info_cache.initialized.wait(), connection_timeout)
         except asyncio.TimeoutError:


### PR DESCRIPTION
## Issue ##
https://github.com/FriendsOfGalaxy/galaxy-integration-steam/issues/86

## Description ##

So I was debugging the plugin while attached to process that launches it with PyCharm, and noticed that [`user_info_cache.UserInfoCache._check_initialized()`](https://github.com/FriendsOfGalaxy/galaxy-integration-steam/blob/master/src/user_info_cache.py#L18) was getting called after the [`TimeoutError`](https://github.com/FriendsOfGalaxy/galaxy-integration-steam/blob/master/src/plugin.py#L264) in the `authenticate()` method happened.

* After increasing the timeout to `120` it started working. It kept working after multiple GoG Galaxy restarts.
* After decreasing the timeout to `30` it stopped working again.

There's probably some race condition, it warrants deeper digging.
For the moment, I think it's worth pushing the workaround, if it helps people to retain their Steam integration.

## Implementation ##
Increased the timeout to 120.