### PR TITLE
Increase incoming message size limit in websockets connection

### DIFF
--- a/src/protocol/websocket_client.py
+++ b/src/protocol/websocket_client.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 logging.getLogger("websockets").setLevel(logging.WARNING)
 
 RECONNECT_INTERVAL_SECONDS = 20
+MAX_INCOMING_MESSAGE_SIZE = 2**24
 
 class WebSocketClient:
     def __init__(
@@ -178,7 +179,7 @@ class WebSocketClient:
             servers = await self._servers_cache.get(str(self.used_server_cell_id))
             for server in servers:
                 try:
-                    self._websocket = await asyncio.wait_for(websockets.connect(server, ssl=self._ssl_context), 5)
+                    self._websocket = await asyncio.wait_for(websockets.connect(server, ssl=self._ssl_context, max_size=MAX_INCOMING_MESSAGE_SIZE), 5)
                     self._protocol_client = ProtocolClient(self._websocket, self._friends_cache, self._games_cache, self._translations_cache, self._stats_cache, self._times_cache, self._user_info_cache, self._steam_app_ownership_ticket_cache, self.used_server_cell_id)
                     return
                 except (asyncio.TimeoutError, OSError, websockets.InvalidURI, websockets.InvalidHandshake):


### PR DESCRIPTION
I've noticed that some of my achievements weren't synchronizing properly. 

Tracked it down to websockets connection dying before the `achievements_import` task finished (before receiving all `ClientGetUserStatsResponse`s), with very helpful error `WebSocket disconnected (1006: ), reconnecting...`. After enabling debug websockets logs, I've noticed that immediately before that, websockets log `1009` error (apparently related to frame/messages sizes; Im not sure why it then is thrown as `1006` :confused: ) and thanks to that found out that by default python's websocket module has a [1MiB size limit for incoming messages](https://websockets.readthedocs.io/en/stable/api.html?highlight=connect#websockets.client.connect):

> The max_size parameter enforces the maximum size for incoming messages in bytes. The default value is 1 MiB. None disables the limit. If a message larger than the maximum size is received, recv() will raise ConnectionClosedError and the connection will be closed with code 1009.

It seems though that steam sometimes sends a bit more. In my case after disabling this limit max I've noticed was just a bit over 1MiB so default is almost enough.

I have no idea though what's the biggest message to expect from steam, and setting this as unlimited seems unsafe so just raising this limit to 16MiB seems saner to me to make sure that this problem disappears for now.

Should potentially fix: #91, #92, #96