### PR TITLE
Throwing InvalidCredentials error for InvalidPassword

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -15,7 +15,8 @@ from galaxy.api.types import (
     LocalGame, LocalGameState, GameLibrarySettings, UserPresence, UserInfo, Subscription, SubscriptionGame
 )
 from galaxy.api.errors import (
-    AuthenticationRequired, UnknownBackendResponse, UnknownError, AccessDenied, BackendTimeout, BackendError
+    AuthenticationRequired, UnknownBackendResponse, UnknownError, AccessDenied, BackendTimeout, BackendError,
+    InvalidCredentials
 )
 from galaxy.api.consts import Platform, LicenseType, SubscriptionDiscovery
 
@@ -188,6 +189,9 @@ class SteamPlugin(Plugin):
                 self.raise_websocket_errors()
             except BackendError as e:
                 logging.info(f"Unable to keep connection with steam backend {repr(e)}")
+                raise
+            except InvalidCredentials:
+                logging.info(f"Invalid credentials during authentication")
                 raise
             except Exception as e:
                 logging.info(f"Internal websocket exception caught during auth {repr(e)}")

--- a/src/protocol/protocol_client.py
+++ b/src/protocol/protocol_client.py
@@ -185,10 +185,8 @@ class ProtocolClient:
         result = await self._login_future
         if result == EResult.OK:
             self._auth_lost_handler = auth_lost_handler
-        elif result == EResult.InvalidPassword:
-            raise galaxy.api.errors.InvalidCredentials({"result": result})
         else:
-            logger.warning(f"Received unknown error, code: {result}")
+            logger.warning(f"authenticate_token failed with code: {result}")
             raise translate_error(result)
 
         await self._protobuf_client.account_info_retrieved.wait()

--- a/src/protocol/protocol_client.py
+++ b/src/protocol/protocol_client.py
@@ -185,8 +185,8 @@ class ProtocolClient:
         result = await self._login_future
         if result == EResult.OK:
             self._auth_lost_handler = auth_lost_handler
-        elif result == EResult.InvalidPassword:  # until we solve real problem with temporarily invalid token
-            raise galaxy.api.errors.BackendError({"result": result})
+        elif result == EResult.InvalidPassword:
+            raise galaxy.api.errors.InvalidCredentials({"result": result})
         else:
             logger.warning(f"Received unknown error, code: {result}")
             raise translate_error(result)


### PR DESCRIPTION
### Issue
If Steam plugin loses authentication for one reason or another, all Steam games will be removed/re-added during the disconnect/connect flow. This makes it impossible to track recent changes in GOG Galaxy, always cluttering most recent view with the whole Steam library.

### Implementation

**GOG Galaxy behaviour (undocumented):**
When GOG Galaxy receives the error `InvalidCredentials` from a plugin, it indicates that the plugin has lost the connection.
![steam_invalid_credentials](https://user-images.githubusercontent.com/17652035/104854956-6db82480-5912-11eb-8fe9-bcb099d5b0b4.PNG)

This allows the user to reconnect while retaining already imported games without updating `addedDate` field.

Checked by observing the table `ProductPurchaseDates` from `%ProgramData%\GOG.com\Galaxy\storage\galaxy-2.0.db`.
Could also be verified by looking at the Daily History of added games in Recent.

### Additional notes
While testing I've discovered that GOG Galaxy synchronizes the added games between separate machines. If I disconnect and reconnect Steam plugin on PC B, it will also update the `addedDate` on PC A.

### Testing
To test either apply the changes manually, or download [allow_reconnect_on_invalid_credentials_test.zip](https://github.com/FriendsOfGalaxy/galaxy-integration-steam/files/5826788/allow_reconnect_on_invalid_credentials_test.zip) and replace plugin contents in `%LOCALAPPDATA%\GOG.com\Galaxy\plugins\installed\steam_ca27391f-2675-49b1-92c0-896d43afa4f8`
