### PR TITLE
Obfuscated private ip fix

### DIFF
--- a/src/protocol/protobuf_client.py
+++ b/src/protocol/protobuf_client.py
@@ -67,9 +67,6 @@ class ProtobufClient:
     async def wait_closed(self):
         pass
 
-    async def _process_packets(self):
-        pass
-
     async def run(self):
         while True:
             for job in self.job_list.copy():
@@ -111,27 +108,6 @@ class ProtobufClient:
         message.protocol_version = 65580
         message.client_instance_id = 0  # ??
         await self._send(EMsg.ClientRegisterAuthTicketWithCM, message)
-
-    async def log_on_web_auth(self, steam_id, miniprofile_id, account_name, token):
-        # magic numbers taken from JavaScript Steam client
-        message = steammessages_clientserver_login_pb2.CMsgClientLogon()
-        message.account_name = account_name
-        message.protocol_version = 65580
-        message.qos_level = 2
-        message.client_os_type = 4294966596
-        message.ui_mode = 4
-        message.chat_mode = 2
-        message.web_logon_nonce = token
-        message.client_instance_id = 0
-
-        try:
-            self.steam_id = steam_id
-            await self.user_authentication_handler('steam_id', self.steam_id)
-            await self.user_authentication_handler('account_id', miniprofile_id)
-            await self._send(EMsg.ClientLogon, message)
-        except Exception:
-            self.steam_id = None
-            raise
 
     async def log_on_password(self, account_name, password, two_factor, two_factor_type):
         def sanitize_password(password):

--- a/src/protocol/protobuf_client.py
+++ b/src/protocol/protobuf_client.py
@@ -152,7 +152,7 @@ class ProtobufClient:
         await self._send(EMsg.ClientLogon, message)
 
     def _get_obfuscated_private_ip(self) -> int:
-        (host, port) = self._socket.local_address
+        host, port = self._socket.local_address
         ip = int(ipaddress.IPv4Address(host))
         obfuscated_ip = ip ^ self._IP_OBFUSCATION_MASK
         logger.debug(f"Local obfuscated IP: {obfuscated_ip}")


### PR DESCRIPTION
### Issue
Currently logging into Steam on more than one machine will end up with lost authentication.

Let's assume the scenario:
* We have two PCs sharing a single public IP address (sitting behind a router)
* Log into GOG Galaxy Steam integration plugin on **PC A**
* Log into GOG Galaxy Steam integration plugin on **PC B**
* Restart GOG Galaxy on **PC A**
* Steam authentication now fails on **PC A** for the plugin 

### Implementation
It looks like Steam uses a combination of public IP address and private IP address to uniquely identify the connections. Specifically the login requests have the `obfuscated_private_ip` field. It is widely used by other unofficial Steam integration libraries ([SteamRE](https://github.com/SteamRE/SteamKit/blob/35792093c6ea1475f9c10086d09d9163f5429ef8/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs#L327), [ValvePython](https://github.com/ValvePython/steam/blob/44d0ef5cc3f420205e3d893abb362a507dd93af2/steam/client/__init__.py#L542)). Usually the solution is to do IP v4 XOR against a mask.

The obfuscation mask seems to be chosen randomly ([0xF00DBAAD](https://github.com/ValvePython/steam/blob/44d0ef5cc3f420205e3d893abb362a507dd93af2/steam/client/__init__.py#L542) and [0xBAADF00D](https://github.com/SteamRE/SteamKit/blob/62d8d4422cc2e3cfc25bd30e4b194a86a6817daa/SteamKit2/SteamKit2/Base/Generated/SteamLanguageInternal.cs#L660). Hence I took creative liberty to pick `0x606573A4` which is as close I could get to GOG STEAM in leet speak.

The private IP is taken from the currently open socket.

Additionally removed couple of unused methods from `protobuf_client.py`

I have tested the implementation on a local network with 2 computers. Also tested if the authentication keeps working in case the private IP changes. Didn't detect any issues.

### Testing
To test either apply the changes manually, or download [obfuscated_private_ip_fix.zip](https://github.com/FriendsOfGalaxy/galaxy-integration-steam/files/5832230/obfuscated_private_ip_fix.zip) (this is v0.54 with the fix) and replace plugin contents in `%LOCALAPPDATA%\GOG.com\Galaxy\plugins\installed\steam_ca27391f-2675-49b1-92c0-896d43afa4f8`