### PR TITLE
Added a check for achievement 'bits' for better stability (#56)

### DIFF
--- a/src/protocol/protobuf_client.py
+++ b/src/protocol/protobuf_client.py
@@ -604,11 +604,17 @@ class ProtobufClient:
             achi_block_enum = 32 * (achievement_block.achievement_id - 1)
             for index, unlock_time in enumerate(achievement_block.unlock_time):
                 if unlock_time > 0:
-                    if str(achievement_block.achievement_id) not in achievements_schema[str(game_id)]['stats'] or \
-                            str(index) not in achievements_schema[str(game_id)]['stats'][str(achievement_block.achievement_id)]['bits']:
-                        logger.warning("Non existent achievement unlocked")
-                        continue
                     try:
+                        if 'bits' not in achievements_schema[str(game_id)]['stats'][str(achievement_block.achievement_id)]:
+                            logger.warning("'bits' not found in achievements_schema while parsing achievement %d for game %s", index, game_id)
+                            logger.info(achievements_schema)
+                            continue
+
+                        if str(achievement_block.achievement_id) not in achievements_schema[str(game_id)]['stats'] or \
+                                str(index) not in achievements_schema[str(game_id)]['stats'][str(achievement_block.achievement_id)]['bits']:
+                            logger.warning("Non existent achievement unlocked")
+                            continue
+
                         if 'english' in achievements_schema[str(game_id)]['stats'][str(achievement_block.achievement_id)]['bits'][str(index)]['display']['name']:
                             name = achievements_schema[str(game_id)]['stats'][str(achievement_block.achievement_id)]['bits'][str(index)]['display']['name']['english']
                         else:
@@ -617,8 +623,8 @@ class ProtobufClient:
                                                       'unlock_time': unlock_time,
                                                      'name': name})
                     except Exception as e:
-                        logger.error("Unable to parse achievement %d from block %s : %s",
-                            index, str(achievement_block.achievement_id), repr(e)
+                        logger.error("Unable to parse achievement %d for game %s from block %s : %s",
+                            index, game_id, str(achievement_block.achievement_id), repr(e)
                         )
                         logger.info(achievs)
                         logger.info(achievements_schema)


### PR DESCRIPTION
Some achievements schemas do not contain the 'bits' field, which caused the plugin to throw an exception and fail to import any achievements for any game (e.g. https://github.com/FriendsOfGalaxy/galaxy-integration-steam/issues/56)

This commit adds an IF test for this field to prevent the plugin from crashing. When the 'bits' field is missing for an achievement, the plugin will only skip this particular achievement to make sure that all other achievements can be imported properly.

I don't know why the 'bits' field is sometimes missing, as it seems quiet important, but it is very rare. I have slightly improved the logging so we can identify which achievements for which games are affected.