### PR TITLE
Update get_custom_library_folders function to new format.

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -212,7 +212,10 @@ def get_custom_library_folders(config_path: str) -> Optional[List[str]]:
             library_folder = library_folders.get(numerical_vdf_key)
             if library_folder is None:
                 break
-            library_path = library_folder.get("path")
+            if "path" in library_folder:
+                library_path = library_folder.get("path")
+            else:
+                library_path = library_folder
             result.append(os.path.join(library_path, "steamapps"))
         return result
     except (OSError, SyntaxError, KeyError):

--- a/src/client.py
+++ b/src/client.py
@@ -212,7 +212,8 @@ def get_custom_library_folders(config_path: str) -> Optional[List[str]]:
             library_folder = library_folders.get(numerical_vdf_key)
             if library_folder is None:
                 break
-            result.append(os.path.join(library_folder, "steamapps"))
+            library_path = library_folder.get("path")
+            result.append(os.path.join(library_path, "steamapps"))
         return result
     except (OSError, SyntaxError, KeyError):
         logger.exception("Failed to parse %s", config_path)

--- a/tests/test_local_games.py
+++ b/tests/test_local_games.py
@@ -182,10 +182,21 @@ def test_get_custom_library_folders(tmp_path):
     data = """\
         "LibraryFolders"
         {
-            "TimeNextStatsReport"		"1507807583"
             "ContentStatsID"		"313251607278753000"
-            "1"		"D:\\Steam"
-            "2"		"E:\\Games\\Steam"
+            "1"
+            {
+                "path"		"D:\\Steam"
+                "label"		"Games"
+                "mounted"		"1"
+                "contentid"		"24707729912644713069"
+            }
+            "2"
+            {
+                "path"		"E:\\Games\\Steam"
+                "label"		"Extras"
+                "mounted"		"2"
+                "contentid"		"24307526915614213469"
+            }
         }
     """
     path = tmp_path / "libraryfolders.vdf"

--- a/tests/test_local_games.py
+++ b/tests/test_local_games.py
@@ -178,7 +178,26 @@ def test_get_app_id_success(tmp_path):
     assert os.path.basename(path)[12:-4] == "92700"
 
 
-def test_get_custom_library_folders(tmp_path):
+def test_get_custom_library_folders_old_format(tmp_path):
+    data = """\
+        "LibraryFolders"
+        {
+            "TimeNextStatsReport"		"1507807583"
+            "ContentStatsID"		"313251607278753000"
+            "1"		"D:\\Steam"
+            "2"		"E:\\Games\\Steam"
+        }
+    """
+    path = tmp_path / "libraryfolders.vdf"
+    path.write_text(dedent(data))
+    library_folders = get_custom_library_folders(path)
+    assert library_folders == [
+        os.path.join(r"D:\Steam", "steamapps"),
+        os.path.join(r"E:\Games\Steam", "steamapps")
+    ]
+
+
+def test_get_custom_library_folders_new_format(tmp_path):
     data = """\
         "LibraryFolders"
         {


### PR DESCRIPTION
What?:
    Updating the get_custom_library_folders function to fit new format Valve
    implemented on the libraryfolders.vdf file.

Why?:
    Because without this change, given the libraryfilders.vdf file exists,
    any installed games on steam, are prevented from being seen by the steam
    integration plugin.