### PR TITLE
fix public profile backend to use community data XML endpoint

### DIFF
--- a/src/backend_public_profiles.py
+++ b/src/backend_public_profiles.py
@@ -222,12 +222,13 @@ class PublicProfilesBackend(BackendInterface):
         try:
             for game in games:
                 game_id = str(game["appid"])
-                last_played = game.get("last_played")
-                if last_played == GAME_DOES_NOT_SUPPORT_LAST_PLAYED_VALUE:
-                    last_played = None
+                # last_played = game.get("last_played")
+                # if last_played == GAME_DOES_NOT_SUPPORT_LAST_PLAYED_VALUE:
+                #     last_played = None
+                last_played = None
                 game_times[game_id] = GameTime(
                     game_id,
-                    int(float(game.get("hours_forever", "0").replace(",", "")) * 60),
+                    int(float((game["hoursOnRecord"] or "0").replace(",", "")) * 60),
                     last_played
                 )
         except (KeyError, ValueError):

--- a/src/user_profile.py
+++ b/src/user_profile.py
@@ -3,7 +3,7 @@ import json
 import re
 
 import aiohttp
-from bs4 import BeautifulSoup, Tag
+import xml.etree.ElementTree as ET
 
 
 logger = logging.getLogger(__name__)
@@ -20,43 +20,36 @@ class UserProfileChecker:
         self._http_client = http_client
 
     async def check_is_public_by_custom_url(self, username) -> bool:
-        url = self._BASE_URL + f'/id/{username}/games/?tab=all'
+        url = self._BASE_URL + f'/id/{username}/games/?xml=1'
         return await self._verify_is_public(url)
 
     async def check_is_public_by_steam_id(self, steam_id) -> bool:
         if not steam_id:
             raise ValueError(f"Incorrect Steam64 ID value: {steam_id}")
-        url = self._BASE_URL + f'/profiles/{steam_id}/games/?tab=all'
+        url = self._BASE_URL + f'/profiles/{steam_id}/games/?xml=1'
         return await self._verify_is_public(url)
 
     async def _verify_is_public(self, url: str) -> bool:
-        profile_data = await self._fetch_profile_data(url)
-
-        if not self._has_user_games(str(profile_data.string)):
-            raise NotPublicGameDetailsOrUserHasNoGames
-        return True
-
-    async def _fetch_profile_data(self, url) -> Tag:
         text = await get_text(await self._http_client.get(url))
-        parsed_html = BeautifulSoup(text, 'html.parser')
-        page = parsed_html.find("div", class_="responsive_page_template_content")
-        if not page:
-            raise ParseError
-        if page.find("div", class_="error_ctn"):
-            raise ProfileDoesNotExist
-        if page.find("div", class_="profile_private_info"):
-            raise ProfileIsNotPublic
-        if not page.find("script", language="javascript"):
-            raise ParseError
-        return page.find("script", language="javascript")
+        root = ET.fromstring(text)
 
-    @staticmethod
-    def _has_user_games(profile_data: str) -> bool:
-        pattern = re.compile(r'var rgGames = (\[.+\])')
-        match = pattern.search(profile_data)
-        if match is None:
-            return False
-        return len(json.loads(match.groups()[0])) > 0
+        error_elm = root.find('./error')
+        error_txt = getattr(error_elm, 'text', None)
+
+        if error_txt:
+            logger.error(f'Error from Steam: {error_txt}')
+            if error_txt == 'The specified profile could not be found.':
+                raise ProfileDoesNotExist
+            if error_txt == 'This profile is private.':
+                raise ProfileIsNotPublic
+            raise ParseError
+
+        game_elm = root.find('./games/game')
+        if not game_elm:
+            logger.error(f'Unable to find any game element')
+            raise NotPublicGameDetailsOrUserHasNoGames
+        
+        return True
 
 
 class ProfileDoesNotExist(Exception):


### PR DESCRIPTION
This fixes the public backend by replacing requests to the community games page (`/profiles/{id}/games?tab=all`) and associated HTML, Javascript, and JSON parsing with requests to the community XML data API (`/profiles/{id}/games?xml=1`). While this endpoint is deprecated, it still works for now and is the only way I know of for accessing a user's list of games with no authentication.

The public backend was broken when the community games page began requiring authentication. I am guessing this was due to an internal switch by Steam from using the deprecated Community XML APIs to the Web APIs which requires authentication to list a user's owned games (even for public profiles).

The XML data API does not return the last-played timestamp, so this value will now always be `None`.

Not sure if this is related to a bug in GOG or the plugin, but the game time will sometimes not update until after restarting GOG. I don't believe this is related to this change as the logs show the correct game time.

In the same vein, achievements are not working.

- https://partner.steamgames.com/documentation/community_data
- https://partner.steamgames.com/doc/webapi/IPlayerService#GetOwnedGames